### PR TITLE
#294 투두 접근 프로세스 변경 및 #297 이슈 close

### DIFF
--- a/Todoary-iOS/Todoary/API/User/UserDeleteDataManager/UserDeleteDataManager.swift
+++ b/Todoary-iOS/Todoary/API/User/UserDeleteDataManager/UserDeleteDataManager.swift
@@ -28,13 +28,11 @@ class UserDeleteDataManager{
         }
     }
     
-    func postAppleUserDelete(_ viewController: AccountViewController){
+    func postAppleUserDelete(_ viewController: AccountViewController, authorizationCode: String){
         
-        guard let appleToken = KeyChain.read(key: Const.UserDefaults.appleRefreshToken) else { return }
-
-        print(appleToken)
+        guard let email = KeyChain.read(key: Const.UserDefaults.email) else { return }
         
-        AF.request("https://todoary.com/auth/revoke/apple", method: .post, parameters: ["appleRefreshToken":appleToken], encoder: JSONParameterEncoder.default).validate().responseDecodable(of: ApiModel.self) { response in
+        AF.request("https://todoary.com/auth/revoke/apple", method: .post, parameters: ["code":authorizationCode, "email": email], encoder: JSONParameterEncoder.default).validate().responseDecodable(of: ApiModel.self) { response in
             
             switch response.result {
             case .success(let result):
@@ -50,7 +48,14 @@ class UserDeleteDataManager{
                     UserDefaults.standard.removeObject(forKey: "accessToken")
                     UserDefaults.standard.removeObject(forKey: "refreshToken")
                     
-                    viewController.navigationController?.popToRootViewController(animated: true)
+                    let alert = ConfirmAlertViewController(title: "계정이 삭제되었습니다.")
+                    alert.alertHandler = {
+                        let vc = LoginViewController()
+                        viewController.navigationController?.pushViewController(vc, animated: false)
+                    }
+                    alert.modalPresentationStyle = .overFullScreen
+                    viewController.present(alert, animated: false, completion: nil)
+                
                 default:
                     print(result.code)
                     

--- a/Todoary-iOS/Todoary/API/User/UserDeleteDataManager/UserDeleteDataManager.swift
+++ b/Todoary-iOS/Todoary/API/User/UserDeleteDataManager/UserDeleteDataManager.swift
@@ -47,11 +47,10 @@ class UserDeleteDataManager{
                     
                     UserDefaults.standard.removeObject(forKey: "accessToken")
                     UserDefaults.standard.removeObject(forKey: "refreshToken")
-                    
+    
                     let alert = ConfirmAlertViewController(title: "계정이 삭제되었습니다.")
                     alert.alertHandler = {
-                        let vc = LoginViewController()
-                        viewController.navigationController?.pushViewController(vc, animated: false)
+                        viewController.navigationController?.pushViewController(LoginViewController(), animated: false)
                     }
                     alert.modalPresentationStyle = .overFullScreen
                     viewController.present(alert, animated: false, completion: nil)

--- a/Todoary-iOS/Todoary/Auth/Login/LoginViewController.swift
+++ b/Todoary-iOS/Todoary/Auth/Login/LoginViewController.swift
@@ -146,6 +146,12 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         setUpView()
         setUpConstraint()
         
+        
+        //로그인VC 접근시 기존 스택VC들 제거
+        let endIndex = (self.navigationController?.viewControllers.endIndex)!
+        
+        self.navigationController?.viewControllers.removeSubrange(0..<endIndex - 1)
+        
 //        UserDefaults.standard.removeObject(forKey: "accessToken")
 //        UserDefaults.standard.removeObject(forKey: "refreshToken")
 //        KeyChain.delete(key: Const.UserDefaults.appleIdentifier)

--- a/Todoary-iOS/Todoary/CommonSource/Alert/BaseAlertViewController.swift
+++ b/Todoary-iOS/Todoary/CommonSource/Alert/BaseAlertViewController.swift
@@ -15,6 +15,8 @@ class BaseAlertViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    var alertHandler: (() -> ())!
+    
     //MARK: - UI
     
     let titleLabel = UILabel().then{
@@ -128,6 +130,7 @@ class BaseAlertViewController: UIViewController {
     }
     
     @objc func confirmBtnDidClicked(){
+        self.alertHandler()
         self.dismiss(animated: false, completion: nil)
     }
 

--- a/Todoary-iOS/Todoary/CommonSource/Alert/CancelAlertViewController.swift
+++ b/Todoary-iOS/Todoary/CommonSource/Alert/CancelAlertViewController.swift
@@ -9,9 +9,6 @@ import UIKit
 
 class CancelAlertViewController: BaseAlertViewController {
     
-    //MARK: - Properties
-    var alertHandler: (() -> ())!
-    
     lazy var cancelBtn = UIButton().then{
         $0.backgroundColor = UIColor(red: 243/255, green: 243/255, blue: 243/255, alpha: 1)
         $0.setTitle("아니오", for: .normal)
@@ -61,10 +58,5 @@ class CancelAlertViewController: BaseAlertViewController {
     
     @objc func cancelBtnDidClicked(){
         self.dismiss(animated: false, completion: nil)
-    }
-    
-    override func confirmBtnDidClicked() {
-        self.alertHandler()
-        super.confirmBtnDidClicked()
     }
 }

--- a/Todoary-iOS/Todoary/Home/Summary/Cell/TodoListTableViewCell.swift
+++ b/Todoary-iOS/Todoary/Home/Summary/Cell/TodoListTableViewCell.swift
@@ -132,6 +132,10 @@ class TodoListTableViewCell: UITableViewCell {
         
         swipeGesture.delegate = self
         backView.addGestureRecognizer(swipeGesture)
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(cellDidTapped))
+        tapGesture.delegate = self
+        backView.addGestureRecognizer(tapGesture)
     }
     
     required init?(coder: NSCoder) {
@@ -163,6 +167,13 @@ class TodoListTableViewCell: UITableViewCell {
         
         setUpViewByCase()
         
+    }
+    
+    @objc func cellDidTapped(){
+        
+        guard let indexPath = getCellIndexPath() else { fatalError("indexPath casting error") }
+        
+        delegate?.cellDidTapped(indexPath)
     }
     
 }
@@ -224,13 +235,23 @@ extension TodoListTableViewCell{
     }
 
     override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-
         if let panGestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer {
             let translation = panGestureRecognizer.translation(in: superview)
             if abs(translation.x) > abs(translation.y) {
                 return true
             }
             return false
+        }
+        
+        if let tapGesture = gestureRecognizer as? UITapGestureRecognizer{
+            return true
+        }
+        return false
+    }
+    
+    override func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if touch.view?.isDescendant(of: self.backView) == true {
+            return true
         }
         return false
     }
@@ -377,6 +398,7 @@ extension TodoListTableViewCell{
 }
 
 protocol SelectedTableViewCellDeliver: AnyObject{
+    func cellDidTapped(_ indexPath: IndexPath)
     func cellWillPin(_ indexPath: IndexPath)
     func cellWillClamp(_ indexPath: IndexPath)
 }

--- a/Todoary-iOS/Todoary/Home/Summary/SummaryBottomViewController.swift
+++ b/Todoary-iOS/Todoary/Home/Summary/SummaryBottomViewController.swift
@@ -472,6 +472,7 @@ extension SummaryBottomViewController: UITableViewDelegate, UITableViewDataSourc
                 cell.delegate = self
                 cell.cellData = todoDataList[indexPath.row-1]
                 cell.cellWillSettingWithData()
+                
                 return cell
             }else{
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: TodoBannerCell.cellIdentifier, for: indexPath)
@@ -504,7 +505,6 @@ extension SummaryBottomViewController: SelectedTableViewCellDeliver{
             let alert = ConfirmAlertViewController(title: "고정은 2개까지만 가능합니다.")
             alert.modalPresentationStyle = .overFullScreen
             self.present(alert, animated: false, completion: nil)
-            
             return
         }
         
@@ -527,10 +527,25 @@ extension SummaryBottomViewController: SelectedTableViewCellDeliver{
         //row 값 -1일 때와, row 값 -1 아닐 때 공통 코드(즉, 자기 자신 아닐 때만 제외)
         clampCell = indexPath
     }
+    
+    func cellDidTapped(_ indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) as? TodoListTableViewCell else { return }
+        
+        if(!cell.isClamp){
+            HomeViewController.dismissBottomSheet()
+            
+            let vc = TodoSettingViewController()
+            vc.todoSettingData = cell.cellData
+            TodoSettingViewController.selectCategory = cell.cellData.categoryId
+            
+            self.homeNavigaiton.pushViewController(vc, animated: true)
+        }else{
+            cell.cellWillMoveOriginalPosition()
+        }
+    }
 }
 
 //MARK: - collectionViewDelegate
-
 extension SummaryBottomViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout{
     
     //TODO: 컬렉션 뷰 셀 selectCategory에 셀 저장

--- a/Todoary-iOS/Todoary/User/Account/AccountViewController.swift
+++ b/Todoary-iOS/Todoary/User/Account/AccountViewController.swift
@@ -244,46 +244,7 @@ extension AccountViewController: ASAuthorizationControllerPresentationContextPro
             
             let authorizationCode = String(data: appleIDCredential.authorizationCode!, encoding: .utf8)!
             
-            print(authorizationCode)
-            
-//            UserDeleteDataManager().postAppleUserDelete(self, authorizationCode: authorizationCode)
-            /*
-            let identityToken = String(data: appleIDCredential.identityToken!, encoding: .ascii)!
-            let userIdentifier = appleIDCredential.user
-            
-            let email: String!
-            let userName: String!
-            
-            if let emailData = appleIDCredential.email, let name =  appleIDCredential.fullName{
-                //email 값 nil 아닌 경우 -> 키체인에 값 저장하기
-                email = emailData
-                userName = "\(name.familyName!)\(name.givenName!)"
-                
-                KeyChain.create(key: Const.UserDefaults.email, value: email)
-                KeyChain.create(key: Const.UserDefaults.userName, value: userName)
-            }else{
-                //email 값 nil인 경우 -> 키체인에서 값 가져오기
-                email = KeyChain.read(key: Const.UserDefaults.email)
-                userName = KeyChain.read(key: Const.UserDefaults.userName)
-            }
-            
-            let userInput = AppleLoginInput(code: authorizationCode!, idToken: identityToken, name: userName, email: email, userIdentifier: userIdentifier)
-            
-            if KeyChain.read(key: Const.UserDefaults.appleRefreshToken) != nil {
-                //userIdentifier값 nil이 아닌 경우 -> 로그인 진행
-                KeyChain.delete(key: Const.UserDefaults.appleIdentifier)
-                KeyChain.delete(key: Const.UserDefaults.appleRefreshToken)
-                
-                AppleLoginDataManager().post(self, parameter: userInput)
-            }else{
-                //userIdentifier값 nil인 경우 -> 회원가입 필요
-                let vc = AgreementViewController()
-                
-                vc.appleUserInfo = userInput
-                
-                self.navigationController?.pushViewController(vc, animated: true)
-            }
-             */
+            UserDeleteDataManager().postAppleUserDelete(self, authorizationCode: authorizationCode)
             
         default:
             break


### PR DESCRIPTION
1. #297: 애플 계정 탈퇴 기능 구현 완료
    1. 애플 계정 탈퇴 전 팝업으로 확인 작업 거치기
    2. 탈퇴 완료 후 안내 팝업 제공
    3. 로그인VC 이동
    4. 네비게이션 스택에 존재하는 VC 전부 제거

2. #294: 투두 접근 프로세스 변경
    1. 투두 셀 클릭시 설정VC 이동으로 프로세스 변경
    2. 투두 왼/오 셀 디자인 변경

3. Alert 프로퍼티 상속관계 수정