### PR TITLE
[fix]: 이메일 인증번호 전송 성공 이후 전송완 료 팝업 띄우기

### DIFF
--- a/Todoary-iOS/Todoary/Auth/PwFind/MailSender.swift
+++ b/Todoary-iOS/Todoary/Auth/PwFind/MailSender.swift
@@ -6,6 +6,7 @@
 //
 
 import skpsmtpmessage
+import UIKit
 
 class MailSender: NSObject, SKPSMTPMessageDelegate {
     static let shared = MailSender()
@@ -20,13 +21,18 @@ class MailSender: NSObject, SKPSMTPMessageDelegate {
     
     var random_num = Int.random(in: 1000...9999)
     
+    var viewController: UIViewController!
+    
     
     func randomGenerate() {
         var num = random_num
         UserDefaults.standard.set(num, forKey: "key")
         }
 
-    func sendEmail(_ email: String) {
+    func sendEmail(email: String, viewController: UIViewController) {
+        
+        self.viewController = viewController
+        
         let message = SKPSMTPMessage()
         message.relayHost = "smtp.gmail.com"
         message.login = TODOARY_EMAIL
@@ -47,9 +53,17 @@ class MailSender: NSObject, SKPSMTPMessageDelegate {
 
     func messageSent(_ message: SKPSMTPMessage!) {
         print("Successfully sent email!")
+        
+        let alert = ConfirmAlertViewController(title: "인증코드가 메일로 발송되었습니다.")
+        alert.modalPresentationStyle = .overFullScreen
+        self.viewController.present(alert, animated: false, completion: nil)
     }
 
     func messageFailed(_ message: SKPSMTPMessage!, error: Error!) {
         print("Sending email failed!")
+        
+        let alert = ConfirmAlertViewController(title: "인증코드 메일 발송을 실패했습니다.")
+        alert.modalPresentationStyle = .overFullScreen
+        self.viewController.present(alert, animated: false, completion: nil)
     }
 }

--- a/Todoary-iOS/Todoary/Auth/PwFind/PwFindViewController.swift
+++ b/Todoary-iOS/Todoary/Auth/PwFind/PwFindViewController.swift
@@ -310,13 +310,8 @@ class PwFindViewController: BaseViewController, UITextFieldDelegate {
             
             idNoticeLb.text = "*유효한 이메일입니다."
             idNoticeLb.textColor = .todoaryGrey
-            
-            MailSender.shared.sendEmail(self.email)
-            
-            //이메일 사용 가능한 경우, 메일 발송 팝업 띄우기
-            let alert = ConfirmAlertViewController(title: "인증코드가 메일로 발송되었습니다.")
-            alert.modalPresentationStyle = .overFullScreen
-            self.present(alert, animated: false, completion: nil)
+        
+            MailSender.shared.sendEmail(email: self.email, viewController: self)
             
         }else if(code == 2017){
             idNoticeLb.text = "*유효하지 않은 이메일입니다. 다시 입력해 주세요."

--- a/Todoary-iOS/Todoary/Auth/SignUp/SignUpViewController.swift
+++ b/Todoary-iOS/Todoary/Auth/SignUp/SignUpViewController.swift
@@ -495,12 +495,7 @@ extension SignUpViewController{
             idCanUseLabel.text = "*사용 가능한 이메일입니다."
             idCanUseLabel.textColor = .todoaryGrey
             
-            MailSender.shared.sendEmail(self.email)
-            
-            //이메일 사용 가능한 경우, 메일 발송 팝업 띄우기
-            let alert = ConfirmAlertViewController(title: "인증코드가 메일로 발송되었습니다.")
-            alert.modalPresentationStyle = .overFullScreen
-            self.present(alert, animated: false, completion: nil)
+            MailSender.shared.sendEmail(email: self.email, viewController: self)
             
             return
             


### PR DESCRIPTION
기존 코드: 인증 버튼 클릭 이후 이메일 유효할 경우 바로 성공 팝업 띄움
fix: 인증 버튼 클릭 이후 이메일 전송 성공한 경우에 성공 팝업 띄우기