### PR TITLE
Refactor/#355: Auth, User 도메인 BaseNetwork 기반 설계 및 BaseNetwork Param 케이스 추가

### DIFF
--- a/Todoary-iOS/Todoary/Network/Entity/Auth/WithdrawalModel.swift
+++ b/Todoary-iOS/Todoary/Network/Entity/Auth/WithdrawalModel.swift
@@ -6,3 +6,20 @@
 //
 
 import Foundation
+
+struct SignUpRequestModel: Codable{
+    
+}
+
+struct AppleSignUpRequestModel: Codable{
+    
+}
+
+struct AppleSignUPResultModel: Codable{
+    
+}
+
+
+struct DeleteAppleAccountModel: Codable{
+    
+}

--- a/Todoary-iOS/Todoary/Network/Entity/User/UserModel.swift
+++ b/Todoary-iOS/Todoary/Network/Entity/User/UserModel.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+struct AlarmActiveStautsModel: Codable{
+    
+}

--- a/Todoary-iOS/Todoary/Network/Service/Auth/SignUpRouter.swift
+++ b/Todoary-iOS/Todoary/Network/Service/Auth/SignUpRouter.swift
@@ -1,8 +1,61 @@
 //
-//  SignUpRouter.swift
+//  AccountRouter.swift
 //  Todoary
 //
 //  Created by 박지윤 on 2023/01/10.
 //
 
 import Foundation
+import Alamofire
+
+enum AccountRouter{
+    /*
+     가입, 탈퇴 관리
+     */
+    case signUp(request: SignUpRequestModel)
+    case signUpWithApple(request: AppleSignUpRequestModel)
+    case deleteAccount
+    case deleteAppleAccount(request: DeleteAppleAccountModel)
+}
+
+/*
+ path 변경 사항 없음
+ 
+ loginApple -> signupApple 네이밍 변경
+ */
+extension AccountRouter: BaseRouter{
+    
+    var path: String{
+        switch self{
+        case .signUp:                   return HTTPMethodURL.POST.signup
+        case .signUpWithApple:          return HTTPMethodURL.POST.loginApple
+        case .deleteAccount:            return HTTPMethodURL.POST.loginApple
+        case .deleteAppleAccount:       return HTTPMethodURL.POST.loginApple
+        }
+    }
+    
+    var method: HTTPMethod{
+        switch self{
+        case .signUp:                   return .post
+        case .signUpWithApple:          return .post
+        case .deleteAccount:            return .patch
+        case .deleteAppleAccount:       return .post
+        }
+    }
+    
+    var parameters: RequestParams {
+        switch self{
+        case .signUp(let request):                      return .requestBody(request)
+        case .signUpWithApple(let request):             return .requestBody(request)
+        case .deleteAccount:                            return .requestPlain
+        case .deleteAppleAccount(let request):          return .requestBody(request)
+        }
+    }
+    
+    var header: HeaderType{
+        switch self{
+        case .deleteAccount:        return .withToken
+        default:                    return .default
+        }
+    }
+}

--- a/Todoary-iOS/Todoary/Network/Service/Auth/SignUpService.swift
+++ b/Todoary-iOS/Todoary/Network/Service/Auth/SignUpService.swift
@@ -1,8 +1,32 @@
 //
-//  SignUpService.swift
+//  AccountService.swift
 //  Todoary
 //
 //  Created by 박지윤 on 2023/01/10.
 //
 
 import Foundation
+
+class AccountService: BaseService{
+    static let shared = AccountService()
+    private override init() {}
+}
+
+extension AccountService {
+    
+    func generateAccount(request: SignUpRequestModel, completion: @escaping (NetworkResult<Any>) -> Void){
+        requestObjectWithEmptyResponse(AccountRouter.signUp(request: request), completion: completion)
+    }
+    
+    func generateAppleAccount(request: AppleSignUpRequestModel, completion: @escaping (NetworkResult<Any>) -> Void){
+        requestObject(AccountRouter.signUpWithApple(request: request), type: AppleSignUPResultModel.self, decodingMode: .model, completion: completion)
+    }
+    
+    func deleteAccount(completion: @escaping (NetworkResult<Any>) -> Void){
+        requestObjectWithEmptyResponse(AccountRouter.deleteAccount, completion: completion)
+    }
+    
+    func deleteAppleAccount(request: DeleteAppleAccountModel, completion: @escaping (NetworkResult<Any>) -> Void){
+        requestObjectWithEmptyResponse(AccountRouter.deleteAppleAccount(request: request), completion: completion)
+    }
+}

--- a/Todoary-iOS/Todoary/Network/Service/Category/CategoryRouter.swift
+++ b/Todoary-iOS/Todoary/Network/Service/Category/CategoryRouter.swift
@@ -11,7 +11,7 @@ import Alamofire
 enum CategoryRouter{
     case getCategories
     case postCategory(requeset: CategoryMakeInput)
-    case fetchCategory(id: Int, request: CategoryMakeInput)
+    case patchCategory(id: Int, request: CategoryMakeInput)
     case deleteCategory(id: Int)
 }
 
@@ -22,7 +22,7 @@ extension CategoryRouter: BaseRouter{
         switch self{
         case .getCategories:                        return HTTPMethodURL.GET.category
         case .postCategory:                         return HTTPMethodURL.POST.category
-        case .fetchCategory(let id, _):             return HTTPMethodURL.PATCH.category + "/\(id)"
+        case .patchCategory(let id, _):             return HTTPMethodURL.PATCH.category + "/\(id)"
         case .deleteCategory(let id):               return HTTPMethodURL.DELETE.category + "/\(id)"
         }
     }
@@ -31,7 +31,7 @@ extension CategoryRouter: BaseRouter{
         switch self{
         case .getCategories:                        return .get
         case .postCategory:                         return .post
-        case .fetchCategory:                        return .patch
+        case .patchCategory:                        return .patch
         case .deleteCategory:                       return .delete
         }
     }
@@ -40,7 +40,7 @@ extension CategoryRouter: BaseRouter{
         switch self{
         case .getCategories:                        return .requestPlain
         case .postCategory(let request):            return .requestBody(request)
-        case .fetchCategory(_, let request):        return .requestBody(request)
+        case .patchCategory(_, let request):        return .requestBody(request)
         case .deleteCategory:                       return .requestPlain
         }
     }

--- a/Todoary-iOS/Todoary/Network/Service/Category/CategoryService.swift
+++ b/Todoary-iOS/Todoary/Network/Service/Category/CategoryService.swift
@@ -23,7 +23,7 @@ extension CategoryService {
     }
     
     func modifyCategory(id: Int, request: CategoryMakeInput, completion: @escaping (NetworkResult<Any>) -> Void){
-        requestObjectWithEmptyResponse(CategoryRouter.fetchCategory(id: id, request: request), completion: completion)
+        requestObjectWithEmptyResponse(CategoryRouter.patchCategory(id: id, request: request), completion: completion)
     }
     
     func deleteCategory(id: Int, completion: @escaping (NetworkResult<Any>) -> Void){

--- a/Todoary-iOS/Todoary/Network/Service/Foundation/BaseRouter.swift
+++ b/Todoary-iOS/Todoary/Network/Service/Foundation/BaseRouter.swift
@@ -89,7 +89,9 @@ extension BaseRouter {
             guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String:Any] else { throw NSError() }
             
             request.httpBody = try JSONSerialization.data(withJSONObject: dictionary, options: [])
-//            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+            
+        case .requestBodyWithDictionary(let body):
+            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
             
         case .queryBody(let query, let body):
             let queryParams = query.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
@@ -128,7 +130,7 @@ extension BaseRouter {
 enum RequestParams {
     case queryBody(_ query: [String: Any], _ body: [String: Any])
     case query(_ query: [String: Any])
-//    case requestBody(_ body: [String: Any])
     case requestBody(_ body: Encodable)
+    case requestBodyWithDictionary(_ body: [String: Any])
     case requestPlain
 }

--- a/Todoary-iOS/Todoary/Network/Service/User/UserRouter.swift
+++ b/Todoary-iOS/Todoary/Network/Service/User/UserRouter.swift
@@ -6,3 +6,55 @@
 //
 
 import Foundation
+import Alamofire
+
+enum AlarmRouter{
+    case patchTodoAlarm(request: Bool)
+    case patchDiaryAlarm(request: Bool)
+    case patchRemindAlarm(request: Bool)
+    case getAlarms
+}
+
+/*
+ path 변경 사항 없음
+ */
+extension AlarmRouter: BaseRouter{
+    
+    var path: String{
+        switch self{
+        case .patchTodoAlarm:                   return HTTPMethodURL.PATCH.todoAlarmActivate
+        case .patchDiaryAlarm:                  return HTTPMethodURL.PATCH.diaryAlarmActivate
+        case .patchRemindAlarm:                 return HTTPMethodURL.PATCH.remindAlarmActivate
+        case .getAlarms:                        return HTTPMethodURL.GET.alarmActivate
+        }
+    }
+    
+    var method: HTTPMethod{
+        switch self{
+        case .patchTodoAlarm:                   return .patch
+        case .patchDiaryAlarm:                  return .patch
+        case .patchRemindAlarm:                 return .patch
+        case .getAlarms:                        return .get
+        }
+    }
+    
+    var parameters: RequestParams {
+        switch self{
+        case .patchTodoAlarm(let request),
+                .patchDiaryAlarm(let request),
+                .patchRemindAlarm(let request):
+            
+            let parameter: [String:Any] = ["isChecked" : request]
+            return .requestBodyWithDictionary(parameter)
+            
+        case .getAlarms:
+            return .requestPlain
+        }
+    }
+    
+    var header: HeaderType{
+        switch self{
+        default:                    return .withToken
+        }
+    }
+}

--- a/Todoary-iOS/Todoary/Network/Service/User/UserService.swift
+++ b/Todoary-iOS/Todoary/Network/Service/User/UserService.swift
@@ -6,3 +6,27 @@
 //
 
 import Foundation
+
+class AlarmService: BaseService{
+    static let shared = AlarmService()
+    private override init() {}
+}
+
+extension AlarmService {
+    
+    func modifyTodoAlarmActiveStatus(request: Bool, completion: @escaping (NetworkResult<Any>) -> Void){
+        requestObjectWithEmptyResponse(AlarmRouter.patchTodoAlarm(request: request), completion: completion)
+    }
+    
+    func modifyDiaryAlarmActiveStatus(request: Bool, completion: @escaping (NetworkResult<Any>) -> Void){
+        requestObjectWithEmptyResponse(AlarmRouter.patchDiaryAlarm(request: request), completion: completion)
+    }
+    
+    func modifyRemindAlarmActiveStatus(request: Bool, completion: @escaping (NetworkResult<Any>) -> Void){
+        requestObjectWithEmptyResponse(AlarmRouter.patchRemindAlarm(request: request), completion: completion)
+    }
+    
+    func getUserAlarmActiveStatus(completion: @escaping (NetworkResult<Any>) -> Void){
+        requestObject(AlarmRouter.getAlarms, type: AlarmActiveStautsModel.self, decodingMode: .model, completion: completion)
+    }
+}


### PR DESCRIPTION
## What is this PR? 🔍
Auth, User 도메인 BaseNetwork 기반 설계 및 BaseNetwork Param 케이스 추가

## Key Changes 🔑

1. BaseRouter RequestParams 케이스 추가
   - requestBody가 구조체만 받을 수 있도록 설정되어있음
   - 프로퍼티 한 가지만 전달한 경우, Router에서 dictionary를 생성 후 서버에 전송할 수 있도록 requestBodyWithDictionary 케이스 추가
   - 사용 예시
   ```swift
    case .patchTodoAlarm(let request),
            .patchDiaryAlarm(let request),
            .patchRemindAlarm(let request):
            
        let parameter: [String:Any] = ["isChecked" : request]
        return .requestBodyWithDictionary(parameter)  
   ```
2. Auth 도메인 회원가입, 탈퇴 설계
   - SignUp으로 일단 네이밍 지정했었는데, 가입/탈퇴를 묶어서 Account로 네이밍 변경
3. User 도메인 알람 설정 설계
   - Alarm으로 네이밍 지정해 설계 
   
## To Reviewers 📢
- 공통 소스부분 수정된 부분이 있어서 풀 받고 사용해주세요

## Related Issues ⛱
#355