### PR TITLE
Fix/#407: 요약화면 투두 카테고리 Tag UI 오류 수정

### DIFF
--- a/Todoary-iOS/Todoary.xcodeproj/project.pbxproj
+++ b/Todoary-iOS/Todoary.xcodeproj/project.pbxproj
@@ -198,6 +198,10 @@
 		E0F3CDC92895696E00A74AB7 /* TodoInDiaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F3CDC82895696E00A74AB7 /* TodoInDiaryTableViewCell.swift */; };
 		E0F998A4288A59A80051C7AA /* UserDeleteDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F998A3288A59A80051C7AA /* UserDeleteDataManager.swift */; };
 		E54C4D9FA6602FAE88B10C99 /* Pods_Todoary_TodoaryUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA1B412CC301CC2E570F1921 /* Pods_Todoary_TodoaryUITests.framework */; };
+		EE06312E29A35326002830FB /* JpaRouter+Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE06312D29A35326002830FB /* JpaRouter+Service.swift */; };
+		EE06313029A362C2002830FB /* LoadingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE06312F29A362C2002830FB /* LoadingTableViewCell.swift */; };
+		EE06313229A362D6002830FB /* Pageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE06313129A362D6002830FB /* Pageable.swift */; };
+		EE06313429A36304002830FB /* PageableResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE06313329A36304002830FB /* PageableResponseModel.swift */; };
 		EE12A17A29A1D6FA009A9750 /* NoTodoInDiaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE12A17929A1D6FA009A9750 /* NoTodoInDiaryTableViewCell.swift */; };
 		EE135A89298D12D500BE3E9D /* CategoryAddCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE135A88298D12D500BE3E9D /* CategoryAddCollectionViewCell.swift */; };
 		EE8BCEF6299F2836004EA821 /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8BCEF5299F2836004EA821 /* UITableView.swift */; };
@@ -434,6 +438,10 @@
 		E0F3CDC82895696E00A74AB7 /* TodoInDiaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoInDiaryTableViewCell.swift; sourceTree = "<group>"; };
 		E0F998A3288A59A80051C7AA /* UserDeleteDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDeleteDataManager.swift; sourceTree = "<group>"; };
 		E6E8C0E6CB0EA8691D12EEB0 /* Pods_TodoaryTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TodoaryTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EE06312D29A35326002830FB /* JpaRouter+Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JpaRouter+Service.swift"; sourceTree = "<group>"; };
+		EE06312F29A362C2002830FB /* LoadingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingTableViewCell.swift; sourceTree = "<group>"; };
+		EE06313129A362D6002830FB /* Pageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pageable.swift; sourceTree = "<group>"; };
+		EE06313329A36304002830FB /* PageableResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableResponseModel.swift; sourceTree = "<group>"; };
 		EE12A17929A1D6FA009A9750 /* NoTodoInDiaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoTodoInDiaryTableViewCell.swift; sourceTree = "<group>"; };
 		EE135A88298D12D500BE3E9D /* CategoryAddCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryAddCollectionViewCell.swift; sourceTree = "<group>"; };
 		EE8BCEF5299F2836004EA821 /* UITableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableView.swift; sourceTree = "<group>"; };
@@ -590,6 +598,7 @@
 			isa = PBXGroup;
 			children = (
 				57C481BA29695344008731D9 /* HTTPMethodURL.swift */,
+				EE06312C29A3530A002830FB /* JPA_Test */,
 				57C481B5296952FF008731D9 /* Foundation */,
 				57C481B0296952A8008731D9 /* Auth */,
 				57C481AF296952A6008731D9 /* User */,
@@ -1057,6 +1066,7 @@
 				57503662288BE3A0006A9070 /* CategoryTodoTableViewCell.swift */,
 				57503660288BE380006A9070 /* CategoryTagCollectionViewCell.swift */,
 				EE135A88298D12D500BE3E9D /* CategoryAddCollectionViewCell.swift */,
+				EE06312F29A362C2002830FB /* LoadingTableViewCell.swift */,
 			);
 			path = Category;
 			sourceTree = "<group>";
@@ -1344,6 +1354,7 @@
 				575DE95F2976523300E61B8F /* TodoResultModel.swift */,
 				575DE95D2976522000E61B8F /* TodoAlarmRequestModel.swift */,
 				AC3A6693297C3B7E00EF42BE /* TodoRequestModel.swift */,
+				EE06313329A36304002830FB /* PageableResponseModel.swift */,
 			);
 			path = Todo;
 			sourceTree = "<group>";
@@ -1381,6 +1392,7 @@
 			children = (
 				57D5B60E29580F8400216C94 /* BaseProtocol.swift */,
 				EE8BCEFB299F4F48004EA821 /* SummaryCellDelegate.swift */,
+				EE06313129A362D6002830FB /* Pageable.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1436,6 +1448,14 @@
 				E06F1AC828A605930066B824 /* AdvertiseTextSettingViewController.swift */,
 			);
 			path = AgreementText;
+			sourceTree = "<group>";
+		};
+		EE06312C29A3530A002830FB /* JPA_Test */ = {
+			isa = PBXGroup;
+			children = (
+				EE06312D29A35326002830FB /* JpaRouter+Service.swift */,
+			);
+			path = JPA_Test;
 			sourceTree = "<group>";
 		};
 		EED1B34C298656D700F14CAC /* DesignSystem */ = {
@@ -1718,6 +1738,7 @@
 				57397F94296D50FF0088B5F4 /* TodoRouter.swift in Sources */,
 				E0218B2928A54C0700E48618 /* AdvertiseTextSettingView.swift in Sources */,
 				57503661288BE380006A9070 /* CategoryTagCollectionViewCell.swift in Sources */,
+				EE06313429A36304002830FB /* PageableResponseModel.swift in Sources */,
 				574A704F28865FEE003C8F99 /* HiddenTransparentButtonView.swift in Sources */,
 				574A704B28852F9B003C8F99 /* DiaryBannerInSummaryTableViewCell.swift in Sources */,
 				E0218B2528A4E99600E48618 /* DiaryStickerViewController + Layout.swift in Sources */,
@@ -1803,6 +1824,7 @@
 				E0AB9EC3287B1C670064CADA /* SettingAgreementView.swift in Sources */,
 				57C481C4296957DB008731D9 /* CategoryModel.swift in Sources */,
 				572E9AB7287BC07A00F915DF /* AskView.swift in Sources */,
+				EE06313029A362C2002830FB /* LoadingTableViewCell.swift in Sources */,
 				AC9128CB287AD5D20056932A /* AccountView.swift in Sources */,
 				E076E9ED28703DEE001E14E1 /* AgreementViewController.swift in Sources */,
 				575DE9662976529F00E61B8F /* AppleSignUpResultModel.swift in Sources */,
@@ -1815,6 +1837,7 @@
 				AC5E27C9288C37E60056EC69 /* TodoSettingView.swift in Sources */,
 				AC3A668E297BC82100EF42BE /* NetworkCheckModel.swift in Sources */,
 				AC5E27DF28901EEF0056EC69 /* AuthInterceptor.swift in Sources */,
+				EE06312E29A35326002830FB /* JpaRouter+Service.swift in Sources */,
 				57F97DD728D9566F00D4697C /* CancelMessageAlertViewController.swift in Sources */,
 				57D5B60B29580F4400216C94 /* BaseTableViewCell.swift in Sources */,
 				E0AB9EB9287B1BA00064CADA /* SettingView.swift in Sources */,
@@ -1839,6 +1862,7 @@
 				57C481B4296952F7008731D9 /* CategoryService.swift in Sources */,
 				574913BB287ADF8E00381BCD /* AlarmSettingTableViewCell.swift in Sources */,
 				ACBAE57A297ADFD600E71CAD /* FcmTokenService.swift in Sources */,
+				EE06313229A362D6002830FB /* Pageable.swift in Sources */,
 				E0AB9EC8287B44C90064CADA /* SettingTableViewCell.swift in Sources */,
 				EE135A89298D12D500BE3E9D /* CategoryAddCollectionViewCell.swift in Sources */,
 				57397F8A296D472C0088B5F4 /* AlarmService.swift in Sources */,

--- a/Todoary-iOS/Todoary/Global/Resource/DesignSystem/CategoryDesignSystem.swift
+++ b/Todoary-iOS/Todoary/Global/Resource/DesignSystem/CategoryDesignSystem.swift
@@ -82,6 +82,7 @@ extension CategoryTag{
         override func bindingData(title: String, color: Int) {
             super.bindingData(title: title, color: color)
             setPadding()
+            sizeToFit()
         }
         
         private func setPadding() {

--- a/Todoary-iOS/Todoary/Global/Source/Protocol/Pageable.swift
+++ b/Todoary-iOS/Todoary/Global/Source/Protocol/Pageable.swift
@@ -1,0 +1,16 @@
+//
+//  Pageable.swift
+//  Todoary
+//
+//  Created by 박소윤 on 2023/02/20.
+//
+
+import Foundation
+
+protocol Pageable{
+    var page: Int { get set }
+    var hasNextPage: Bool { get set }
+    var isPaging: Bool { get set }
+    func beginPaging()
+    func todoRequestIsEmpty()
+}

--- a/Todoary-iOS/Todoary/Network/Entity/Todo/PageableResponseModel.swift
+++ b/Todoary-iOS/Todoary/Network/Entity/Todo/PageableResponseModel.swift
@@ -1,0 +1,30 @@
+//
+//  PageableResponseModel.swift
+//  Todoary
+//
+//  Created by 박소윤 on 2023/02/20.
+//
+
+import Foundation
+
+struct PageableResponseModel: Codable{
+    
+    let contents: [TodoResultModel]
+    let pageInfo: PageInfoResponseModel
+    
+    struct PageInfoResponseModel: Codable{
+        let empty: Bool
+        let last: Bool
+    }
+}
+
+extension PageableResponseModel{
+    
+    var isEmpty: Bool{
+        pageInfo.empty
+    }
+    
+    var isLast: Bool{
+        pageInfo.last
+    }
+}

--- a/Todoary-iOS/Todoary/Network/Entity/Todo/TodoResultModel.swift
+++ b/Todoary-iOS/Todoary/Network/Entity/Todo/TodoResultModel.swift
@@ -57,40 +57,4 @@ struct TodoResultModel: Codable, Equatable{
         
         return "\(Int(dateArr[1])!)월 \(Int(dateArr[2])!)일"
     }
-    
-    var categoryWidth: Int{
-        
-        if(isPinned! && isAlarmEnabled){
-            switch self.categoryTitle.count{
-            case 1:
-                return 11 + 7*2
-            case 2:
-                return 22 + 12*2
-            case 3:
-                return 32 + 10*2
-            case 4:
-                return 43 + 8*2
-            case 5:
-                return 53 + 6*2
-            default:
-                return 0
-            }
-        }else{
-            switch self.categoryTitle.count{
-            case 1:
-                return 11 + 24
-            case 2:
-                return 22 + 24
-            case 3:
-                return 32 + 24
-            case 4:
-                return 43 + 24
-            case 5:
-                return 53 + 6*2
-            default:
-                return 0
-            }
-//            return self.categoryTitle.count < 5 ? 24 : 6*2
-        }
-    }
 }

--- a/Todoary-iOS/Todoary/Network/Service/JPA_Test/JpaRouter+Service.swift
+++ b/Todoary-iOS/Todoary/Network/Service/JPA_Test/JpaRouter+Service.swift
@@ -1,0 +1,48 @@
+//
+//  JpaRouter.swift
+//  Todoary
+//
+//  Created by 박소윤 on 2023/02/20.
+//
+
+import Foundation
+import Alamofire
+
+enum JpaRouter{
+    case getTodoByCategory(id: Int, page: Int)
+}
+
+extension JpaRouter: BaseRouter{
+    
+    var path: String{
+        switch self{
+        case .getTodoByCategory(let categoryId, _):
+            return HTTPMethodURL.GET.todoByCategory + "/\(categoryId)" + "/page"
+        }
+    }
+    
+    var method: HTTPMethod{
+        switch self{
+        case .getTodoByCategory:                return .get
+        }
+    }
+    
+    var parameters: RequestParams {
+        switch self{
+        case .getTodoByCategory(_ , let page):
+            let parameter: [String:Any] = ["page" : page, "size" : 1]
+                                                    return .query(parameter)
+        }
+    }
+    
+    var baseURL: String{
+        return "https://dev.todoary.com"
+    }
+    
+    var header: HeaderType{
+        switch self{
+        default:                    return .withToken
+        }
+    }
+}
+

--- a/Todoary-iOS/Todoary/Network/Service/Todo/TodoRouter.swift
+++ b/Todoary-iOS/Todoary/Network/Service/Todo/TodoRouter.swift
@@ -12,7 +12,7 @@ enum TodoRouter{
     case postTodo(request: TodoRequestModel)
     case patchTodo(id: Int, request: TodoRequestModel)
     case getTodoByDate(date: String)
-    case getTodoByCategory(id: Int)
+    case getTodoByCategory(id: Int, page: Int)
     case patchCheck(id: Int, isChecked: Bool)
     case patchPin(id: Int, isPinned: Bool)
     case patchAlarm(id: Int, request: TodoAlarmRequestModel)
@@ -27,7 +27,7 @@ extension TodoRouter: BaseRouter{
         case .postTodo:                                 return HTTPMethodURL.POST.todo
         case .patchTodo(let id, _):                     return HTTPMethodURL.PATCH.todo + "/\(id)"
         case .getTodoByDate(let date):                  return HTTPMethodURL.GET.todoByDate + "/\(date)"
-        case .getTodoByCategory(let categoryId):        return HTTPMethodURL.GET.todoByCategory + "/\(categoryId)"
+        case .getTodoByCategory(let categoryId, _):     return HTTPMethodURL.GET.todoByCategory + "/\(categoryId)" //+ "/page"
         case .patchCheck:                               return HTTPMethodURL.PATCH.todoCheckbox
         case .patchPin:                                 return HTTPMethodURL.PATCH.todoPin
         case .patchAlarm(let id, _):                    return HTTPMethodURL.PATCH.todoAlarm + "/\(id)/alarm"
@@ -55,7 +55,9 @@ extension TodoRouter: BaseRouter{
         case .postTodo(let request):                return .requestBody(request)
         case .patchTodo(_, let request):            return .requestBody(request)
         case .getTodoByDate:                        return .requestPlain
-        case .getTodoByCategory:                    return .requestPlain
+        case .getTodoByCategory(_ , let page):      return .requestPlain
+//            let parameter: [String:Any] = ["page" : page, "size" : 1]
+//                                                    return .query(parameter)
         case .patchCheck(let id, let isChecked):
             let parameter: [String:Any] = ["todoId" : id, "isChecked" : isChecked]
                                                     return .requestBodyWithDictionary(parameter)

--- a/Todoary-iOS/Todoary/Network/Service/Todo/TodoService.swift
+++ b/Todoary-iOS/Todoary/Network/Service/Todo/TodoService.swift
@@ -26,8 +26,8 @@ extension TodoService {
         requestObject(TodoRouter.getTodoByDate(date: date), type: [TodoResultModel].self, decodingMode: .model, completion: completion)
     }
     
-    func getTodoByCategory(id: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
-        requestObject(TodoRouter.getTodoByCategory(id: id), type: [TodoResultModel].self, decodingMode: .model, completion: completion)
+    func getTodoByCategory(id: Int, page: Int, completion: @escaping (NetworkResult<Any>) -> Void) { //PageableResponseModel [TodoResultModel]
+        requestObject(TodoRouter.getTodoByCategory(id: id, page: page), type: [TodoResultModel].self, decodingMode: .model, completion: completion)
     }
     
     func modifyTodoCheckStatus(id: Int, isChecked: Bool, completion: @escaping (NetworkResult<Any>) -> Void) {

--- a/Todoary-iOS/Todoary/Presentation/Cells/Summary/Bottom/TodoInSummaryTableViewCell.swift
+++ b/Todoary-iOS/Todoary/Presentation/Cells/Summary/Bottom/TodoInSummaryTableViewCell.swift
@@ -57,7 +57,7 @@ class TodoInSummaryTableViewCell: BaseTableViewCell {
         $0.setTypoStyleWithSingleLine(typoStyle: .bold15_18)
     }
     
-    private let categoryButton = CategoryTag.generateForMainTodo()
+    private let categoryTag = CategoryTag.generateForMainTodo()
     
     private lazy var pinImage = UIImageView().then{
         $0.image = Image.pushPin
@@ -95,7 +95,7 @@ class TodoInSummaryTableViewCell: BaseTableViewCell {
         checkBox.isSelected = false
         
         titleLabel.snp.removeConstraints()
-        categoryButton.snp.removeConstraints()
+        categoryTag.snp.removeConstraints()
         removeHiddenViews()
         isClamp = false
     }
@@ -113,7 +113,7 @@ class TodoInSummaryTableViewCell: BaseTableViewCell {
         
         backgroundShadowView.addSubview(checkBox)
         backgroundShadowView.addSubview(titleLabel)
-        backgroundShadowView.addSubview(categoryButton)
+        backgroundShadowView.addSubview(categoryTag)
     }
     
     override func layout() {
@@ -173,7 +173,7 @@ class TodoInSummaryTableViewCell: BaseTableViewCell {
         timeLabel.text = todo.convertTime
         checkBox.isSelected = todo.isChecked
         
-        categoryButton.bindingData(title: todo.categoryTitle, color: todo.color)
+        categoryTag.bindingData(title: todo.categoryTitle, color: todo.color)
         
         hiddenLeftView.pinButton.isSelected = todo.isPinned! ? true : false
         hiddenLeftView.alarmBtn.isSelected = todo.isAlarmEnabled ? true : false
@@ -405,11 +405,11 @@ extension TodoInSummaryTableViewCell{
             $0.centerY.equalToSuperview().offset(1.4)
         }
 
-        categoryButton.snp.makeConstraints{
+        categoryTag.snp.makeConstraints{
             $0.centerY.equalToSuperview().offset(1)
         }
         
-        let titleTrailing: CGFloat = categoryButton.bounds.width + 6
+        let titleTrailing: CGFloat = categoryTag.bounds.width + 6
         
         if(todo.isAlarmEnabled){
             
@@ -435,7 +435,7 @@ extension TodoInSummaryTableViewCell{
                 pinImage.snp.makeConstraints{
                     $0.trailing.equalTo(alarmImage.snp.leading).offset(-2)
                 }
-                categoryButton.snp.makeConstraints{
+                categoryTag.snp.makeConstraints{
                     $0.trailing.equalTo(pinImage.snp.leading).offset(-3)
                 }
  
@@ -452,7 +452,7 @@ extension TodoInSummaryTableViewCell{
                     $0.trailing.equalTo(timeLabel.snp.leading).offset(-4)
                 }
                 
-                categoryButton.snp.makeConstraints{
+                categoryTag.snp.makeConstraints{
                     $0.trailing.equalTo(alarmImage.snp.leading).offset(-7)
                 }
                 
@@ -468,14 +468,14 @@ extension TodoInSummaryTableViewCell{
                 pinImage.snp.makeConstraints{
                     $0.trailing.equalToSuperview().offset(-18)
                 }
-                categoryButton.snp.makeConstraints{
+                categoryTag.snp.makeConstraints{
                     $0.trailing.equalTo(pinImage.snp.leading).offset(-7)
                 }
                 titleLabel.snp.makeConstraints{
                     $0.trailing.equalToSuperview().offset(-(titleTrailing + 34))
                 }
             }else{
-                categoryButton.snp.makeConstraints{
+                categoryTag.snp.makeConstraints{
                     $0.trailing.equalToSuperview().offset(-18)
                 }
                 titleLabel.snp.makeConstraints{

--- a/Todoary-iOS/Todoary/Presentation/Cells/Summary/Bottom/TodoInSummaryTableViewCell.swift
+++ b/Todoary-iOS/Todoary/Presentation/Cells/Summary/Bottom/TodoInSummaryTableViewCell.swift
@@ -412,7 +412,7 @@ extension TodoInSummaryTableViewCell{
             make.centerY.equalToSuperview().offset(1)
         }
         
-        let titleTrailing: Int = todo.categoryWidth + 6
+        let titleTrailing: CGFloat = categoryButton.bounds.width + 6
         
         if(todo.isAlarmEnabled){
             

--- a/Todoary-iOS/Todoary/Presentation/Cells/Summary/Bottom/TodoInSummaryTableViewCell.swift
+++ b/Todoary-iOS/Todoary/Presentation/Cells/Summary/Bottom/TodoInSummaryTableViewCell.swift
@@ -111,29 +111,29 @@ class TodoInSummaryTableViewCell: BaseTableViewCell {
         
         baseView.addSubview(backgroundShadowView)
         
-        self.backgroundShadowView.addSubview(checkBox)
-        self.backgroundShadowView.addSubview(titleLabel)
-        self.backgroundShadowView.addSubview(categoryButton)
+        backgroundShadowView.addSubview(checkBox)
+        backgroundShadowView.addSubview(titleLabel)
+        backgroundShadowView.addSubview(categoryButton)
     }
     
     override func layout() {
         
         super.layout()
         
-        baseView.snp.makeConstraints{ make in
-            make.height.equalTo(75)
+        baseView.snp.makeConstraints{
+            $0.height.equalTo(75)
         }
-        backgroundShadowView.snp.makeConstraints{ make in
-            make.leading.equalToSuperview().offset(32)
-            make.trailing.equalToSuperview().offset(-30)
-            make.top.equalToSuperview()
-            make.bottom.equalToSuperview().offset(-15)
+        backgroundShadowView.snp.makeConstraints{
+            $0.leading.equalToSuperview().offset(32)
+            $0.trailing.equalToSuperview().offset(-30)
+            $0.top.equalToSuperview()
+            $0.bottom.equalToSuperview().offset(-15)
         }
-        checkBox.snp.makeConstraints{ make in
-            make.width.height.equalTo(24)
-            make.leading.equalToSuperview().offset(19)
-            make.top.equalToSuperview().offset(18)
-            make.bottom.equalToSuperview().offset(-18)
+        checkBox.snp.makeConstraints{
+            $0.width.height.equalTo(24)
+            $0.leading.equalToSuperview().offset(19)
+            $0.top.equalToSuperview().offset(18)
+            $0.bottom.equalToSuperview().offset(-18)
         }
     }
     
@@ -228,7 +228,6 @@ extension TodoInSummaryTableViewCell{
                                         width: bounds.size.width,
                                         height: bounds.size.height)
                     superView?.bringSubviewToFront(hiddenRightView)
-                    //                    superView?.bringSubviewToFront(HomeViewController.bottomSheetVC.addButton)
                     UIView.animate(withDuration: 0.4, animations: {self.frame = clampFrame})
                 }else{
                     isViewAdd = .left
@@ -350,24 +349,24 @@ extension TodoInSummaryTableViewCell{
             self.superview?.superview?.sendSubviewToBack(hiddenLeftView)
             self.superview?.superview?.sendSubviewToBack(hiddenView)
             
-            hiddenView.snp.makeConstraints{ make in
-                make.leading.equalToSuperview().offset(32)
-                make.trailing.equalToSuperview().offset(-30)
-                make.height.equalTo(60)
-                make.top.equalTo(backgroundShadowView)
-                make.bottom.equalTo(backgroundShadowView)
+            hiddenView.snp.makeConstraints{
+                $0.leading.equalToSuperview().offset(32)
+                $0.trailing.equalToSuperview().offset(-30)
+                $0.height.equalTo(60)
+                $0.top.equalTo(backgroundShadowView)
+                $0.bottom.equalTo(backgroundShadowView)
             }
             
-            hiddenRightView.snp.makeConstraints{ make in
-                make.trailing.equalToSuperview().offset(-30)
-                make.top.equalTo(backgroundShadowView)
-                make.bottom.equalTo(backgroundShadowView)
+            hiddenRightView.snp.makeConstraints{
+                $0.trailing.equalToSuperview().offset(-30)
+                $0.top.equalTo(backgroundShadowView)
+                $0.bottom.equalTo(backgroundShadowView)
             }
             
-            hiddenLeftView.snp.makeConstraints{ make in
-                make.leading.equalToSuperview().offset(32)
-                make.top.equalTo(backgroundShadowView)
-                make.bottom.equalTo(backgroundShadowView)
+            hiddenLeftView.snp.makeConstraints{
+                $0.leading.equalToSuperview().offset(32)
+                $0.top.equalTo(backgroundShadowView)
+                $0.bottom.equalTo(backgroundShadowView)
             }
         }
     }
@@ -401,9 +400,9 @@ extension TodoInSummaryTableViewCell{
     
     func setUpViewByCase(){
         
-        titleLabel.snp.makeConstraints{ make in
-            make.leading.equalTo(checkBox.snp.trailing).offset(13)
-            make.centerY.equalToSuperview().offset(1.4)
+        titleLabel.snp.makeConstraints{
+            $0.leading.equalTo(checkBox.snp.trailing).offset(13)
+            $0.centerY.equalToSuperview().offset(1.4)
         }
 
         categoryButton.snp.makeConstraints{
@@ -414,12 +413,12 @@ extension TodoInSummaryTableViewCell{
         
         if(todo.isAlarmEnabled){
             
-            self.backgroundShadowView.addSubview(timeLabel)
+            backgroundShadowView.addSubview(timeLabel)
             
-            timeLabel.snp.makeConstraints{ make in
-                make.trailing.equalToSuperview().offset(-18)
-                make.centerY.equalToSuperview().offset(2)
-                make.height.equalTo(15)
+            timeLabel.snp.makeConstraints{
+                $0.trailing.equalToSuperview().offset(-18)
+                $0.centerY.equalToSuperview().offset(2)
+                $0.height.equalTo(15)
             }
             
             alarmImageConstraint()
@@ -427,38 +426,38 @@ extension TodoInSummaryTableViewCell{
             
             if(todo.isPinned!){
                 
-                alarmImage.snp.makeConstraints{ make in
-                    make.trailing.equalTo(timeLabel.snp.leading).offset(-2)
+                alarmImage.snp.makeConstraints{
+                    $0.trailing.equalTo(timeLabel.snp.leading).offset(-2)
                 }
                 
                 pinImageConstraint()
                 
-                pinImage.snp.makeConstraints{ make in
-                    make.trailing.equalTo(alarmImage.snp.leading).offset(-2)
+                pinImage.snp.makeConstraints{
+                    $0.trailing.equalTo(alarmImage.snp.leading).offset(-2)
                 }
-                categoryButton.snp.makeConstraints{ make in
-                    make.trailing.equalTo(pinImage.snp.leading).offset(-3)
+                categoryButton.snp.makeConstraints{
+                    $0.trailing.equalTo(pinImage.snp.leading).offset(-3)
                 }
  
-                titleLabel.snp.updateConstraints{ make in
-                    make.leading.equalTo(checkBox.snp.trailing).offset(7)
+                titleLabel.snp.updateConstraints{
+                    $0.leading.equalTo(checkBox.snp.trailing).offset(7)
                 }
                 
-                titleLabel.snp.makeConstraints{ make in
-                    make.trailing.equalToSuperview().offset( -(titleTrailing + 100))
+                titleLabel.snp.makeConstraints{
+                    $0.trailing.equalToSuperview().offset( -(titleTrailing + 100))
                 }
             }else{
                 
-                alarmImage.snp.makeConstraints{ make in
-                    make.trailing.equalTo(timeLabel.snp.leading).offset(-4)
+                alarmImage.snp.makeConstraints{
+                    $0.trailing.equalTo(timeLabel.snp.leading).offset(-4)
                 }
                 
-                categoryButton.snp.makeConstraints{ make in
-                    make.trailing.equalTo(alarmImage.snp.leading).offset(-7)
+                categoryButton.snp.makeConstraints{
+                    $0.trailing.equalTo(alarmImage.snp.leading).offset(-7)
                 }
                 
-                titleLabel.snp.makeConstraints{ make in
-                    make.trailing.equalToSuperview().offset(-(titleTrailing + 90)) //160
+                titleLabel.snp.makeConstraints{
+                    $0.trailing.equalToSuperview().offset(-(titleTrailing + 90)) //160
                 }
             }
         }else{
@@ -466,21 +465,21 @@ extension TodoInSummaryTableViewCell{
                 
                 pinImageConstraint()
                 
-                pinImage.snp.makeConstraints{ make in
-                    make.trailing.equalToSuperview().offset(-18)
+                pinImage.snp.makeConstraints{
+                    $0.trailing.equalToSuperview().offset(-18)
                 }
-                categoryButton.snp.makeConstraints{ make in
-                    make.trailing.equalTo(pinImage.snp.leading).offset(-7)
+                categoryButton.snp.makeConstraints{
+                    $0.trailing.equalTo(pinImage.snp.leading).offset(-7)
                 }
-                titleLabel.snp.makeConstraints{ make in
-                    make.trailing.equalToSuperview().offset(-(titleTrailing + 34))
+                titleLabel.snp.makeConstraints{
+                    $0.trailing.equalToSuperview().offset(-(titleTrailing + 34))
                 }
             }else{
-                categoryButton.snp.makeConstraints{ make in
-                    make.trailing.equalToSuperview().offset(-18)
+                categoryButton.snp.makeConstraints{
+                    $0.trailing.equalToSuperview().offset(-18)
                 }
-                titleLabel.snp.makeConstraints{ make in
-                    make.trailing.equalToSuperview().offset(-(titleTrailing + 18))
+                titleLabel.snp.makeConstraints{
+                    $0.trailing.equalToSuperview().offset(-(titleTrailing + 18))
                 }
             }
         }
@@ -490,10 +489,10 @@ extension TodoInSummaryTableViewCell{
         
         self.backgroundShadowView.addSubview(pinImage)
         
-        pinImage.snp.makeConstraints{ make in
-            make.width.equalTo(14)
-            make.height.equalTo(13.2)
-            make.centerY.equalToSuperview().offset(1)
+        pinImage.snp.makeConstraints{
+            $0.width.equalTo(14)
+            $0.height.equalTo(13.2)
+            $0.centerY.equalToSuperview().offset(1)
         }
     }
     
@@ -501,10 +500,10 @@ extension TodoInSummaryTableViewCell{
         
         self.backgroundShadowView.addSubview(alarmImage)
         
-        alarmImage.snp.makeConstraints{ make in
-            make.width.equalTo(14)
-            make.height.equalTo(13.2)
-            make.centerY.equalToSuperview().offset(0.6)
+        alarmImage.snp.makeConstraints{
+            $0.width.equalTo(14)
+            $0.height.equalTo(13.2)
+            $0.centerY.equalToSuperview().offset(0.6)
         }
     }
 

--- a/Todoary-iOS/Todoary/Presentation/Cells/Summary/Bottom/TodoInSummaryTableViewCell.swift
+++ b/Todoary-iOS/Todoary/Presentation/Cells/Summary/Bottom/TodoInSummaryTableViewCell.swift
@@ -406,10 +406,8 @@ extension TodoInSummaryTableViewCell{
             make.centerY.equalToSuperview().offset(1.4)
         }
 
-        categoryButton.snp.makeConstraints{ make in
-            make.width.equalTo(todo.categoryWidth)
-            make.height.equalTo(21)
-            make.centerY.equalToSuperview().offset(1)
+        categoryButton.snp.makeConstraints{
+            $0.centerY.equalToSuperview().offset(1)
         }
         
         let titleTrailing: CGFloat = categoryButton.bounds.width + 6

--- a/Todoary-iOS/Todoary/Presentation/Cells/Summary/Category/LoadingTableViewCell.swift
+++ b/Todoary-iOS/Todoary/Presentation/Cells/Summary/Category/LoadingTableViewCell.swift
@@ -1,0 +1,28 @@
+//
+//  LoadingTableViewCell.swift
+//  Todoary
+//
+//  Created by 박소윤 on 2023/02/20.
+//
+
+import Foundation
+
+class LoadingTableViewCell: BaseTableViewCell{
+    let loadingView = UIActivityIndicatorView()
+    
+    override func hierarchy() {
+        super.hierarchy()
+        self.baseView.addSubview(loadingView)
+    }
+    
+    override func layout() {
+        super.layout()
+        loadingView.snp.makeConstraints{
+            $0.centerY.centerX.equalToSuperview()
+        }
+    }
+    
+    func startLoading(){
+        loadingView.startAnimating()
+    }
+}

--- a/Todoary-iOS/Todoary/Presentation/ViewControllers/Summary/Category/CategoryViewController.swift
+++ b/Todoary-iOS/Todoary/Presentation/ViewControllers/Summary/Category/CategoryViewController.swift
@@ -12,7 +12,11 @@ class CategoryViewController: BaseViewController {
     //MARK: - Properties
     
     private var isCategoryAdd = false
-    private var isEditingMode = false
+    private var isEditingMode = false{
+        didSet{
+            mainView.todoTableView.reloadData()
+        }
+    }
     private var willDelete = false
     
     let collectionViewInitialIndex: IndexPath = [0,0]
@@ -73,22 +77,7 @@ class CategoryViewController: BaseViewController {
     
     //MARK: - Action
     
-    @objc func trashButtonDidClicked(){
-        
-        let leading = isEditingMode ? 32 : 58
-        let trailing = isEditingMode ? -30 : -4
-        
-        for i in 0..<todoData.count{
-            guard let cell = mainView.todoTableView.cellForRow(at: [0,i]) as? CategoryTodoTableViewCell else { fatalError() }
-            
-            cell.contentView.snp.updateConstraints{ make in
-                make.leading.equalToSuperview().offset(leading)
-                make.trailing.equalToSuperview().offset(trailing)
-            }
-            
-            cell.deleteButton.isHidden.toggle()
-        }
-        
+    @objc private func trashButtonDidClicked(){
         isEditingMode.toggle()
     }
     
@@ -101,23 +90,6 @@ class CategoryViewController: BaseViewController {
             $0.currentCategoryCount = categories.count
             $0.completion = {
                 self.requestGetCategories()
-            }
-        }
-    }
-    
-    
-    //MARK: - Helper
-    
-    func initTodoCellConstraint(){
-        
-        isEditingMode = false
-        
-        for i in 0..<mainView.todoTableView.numberOfRows(inSection: 0)-1{
-            guard let cell = mainView.todoTableView.cellForRow(at: [0,i]) as? CategoryTodoTableViewCell else { return }
-            cell.contentView.snp.updateConstraints{ make in
-                make.leading.equalToSuperview().offset(32)
-                make.trailing.equalToSuperview().offset(-30)
-                cell.deleteButton.isHidden = true
             }
         }
     }

--- a/Todoary-iOS/Todoary/Presentation/ViewControllers/Summary/Category/CategoryViewController.swift
+++ b/Todoary-iOS/Todoary/Presentation/ViewControllers/Summary/Category/CategoryViewController.swift
@@ -289,24 +289,20 @@ extension CategoryViewController: UICollectionViewDelegate, UICollectionViewData
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         
-        if(indexPath.row != categories.count){
-            
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryTagCollectionViewCell.cellIdentifier, for: indexPath) as? CategoryTagCollectionViewCell else { fatalError() }
-            
-            let data = categories[indexPath.row]
-            cell.bindingData(title: data.title, color: data.color)
-            cell.addGestureRecognizer(UILongPressGestureRecognizer(target: self,
-                                                                   action: #selector(categoryBottomSheetWillShowAndModifyCategory)))
-            
-            if(indexPath == selectCategoryIndex){
-                cell.setSelectState()
-            }
-            
-            return cell
-        }else{
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryAddCollectionViewCell.cellIdentifier, for: indexPath)
-            return cell
+        if(indexPath.row == categories.count){
+            return collectionView.dequeueReusableCell(for: indexPath, cellType: CategoryAddCollectionViewCell.self)
         }
+
+        let data = categories[indexPath.row]
+        let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: CategoryTagCollectionViewCell.self).then{
+            $0.bindingData(title: data.title, color: data.color)
+            $0.addGestureRecognizer(UILongPressGestureRecognizer(target: self,
+                                                                 action: #selector(categoryBottomSheetWillShowAndModifyCategory)))
+            if(indexPath == selectCategoryIndex){
+                $0.setSelectState()
+            }
+        }
+        return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/Todoary-iOS/Todoary/Presentation/ViewControllers/Summary/Category/CategoryViewController.swift
+++ b/Todoary-iOS/Todoary/Presentation/ViewControllers/Summary/Category/CategoryViewController.swift
@@ -7,9 +7,19 @@
 
 import UIKit
 
-class CategoryViewController: BaseViewController {
+class CategoryViewController: BaseViewController, Pageable {
     
     //MARK: - Properties
+    
+    var page: Int = 0{
+        didSet{
+            if(page == 0){
+                hasNextPage = false
+            }
+        }
+    }
+    var isPaging: Bool = false
+    var hasNextPage: Bool = false
     
     private var isCategoryAdd = false
     private var isEditingMode = false{
@@ -23,6 +33,7 @@ class CategoryViewController: BaseViewController {
     var selectCategoryIndex : IndexPath!{
         didSet{
             isEditingMode = false
+            page = 0
         }
     }
 
@@ -155,20 +166,43 @@ extension CategoryViewController: CategoryTodoCellDelegate{
         
         let categoryId: Int = categories.count == 1 ? categories[0].id : categories[selectCategoryIndex.row].id
         
-        TodoService.shared.getTodoByCategory(id: categoryId) { result in
+        TodoService.shared.getTodoByCategory(id: categoryId, page: page) { result in
             switch result {
             case .success(let data):
                 print("[getTodoByCategory] success")
                 if let data = data as? [TodoResultModel]{
                     self.todoData = data
                 }
+//                if let data = data as? PageableResponseModel{
+//                    self.processResponseGetTodo(data: data)
+//                }
                 break
             default:
-                print("[getTodoByCategory] fail")
+                print("[getTodoByCategory] fail", result)
                 DataBaseErrorAlert.show(in: self)
                 break
             }
         }
+    }
+    
+    private func processResponseGetTodo(data: PageableResponseModel){
+        
+        hasNextPage = !data.isLast
+        
+        if(page == 0){
+            todoData = data.contents
+        }else{
+            todoData.append(contentsOf: data.contents)
+        }
+        
+        if(data.isEmpty){
+            todoRequestIsEmpty()
+        }
+    }
+    
+    func todoRequestIsEmpty() {
+        isPaging = false
+        mainView.todoTableView.reloadSections(IndexSet(integer: 1), with: .none)
     }
     
     func requestDeleteTodo(cell: CategoryTodoTableViewCell) {
@@ -232,10 +266,23 @@ extension CategoryViewController: CategoryTodoCellDelegate{
 extension CategoryViewController: UITableViewDelegate, UITableViewDataSource{
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return todoData.count != 0 ? todoData.count + 1 : 2
+        if(section == 0){
+            return todoData.count != 0 ? todoData.count + 1 : 2
+        }else if(section == 1 && isPaging && hasNextPage){
+            return 1
+        }else{
+            return 0
+        }
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        if(indexPath.section == 1){
+            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: LoadingTableViewCell.self).then{
+                $0.startLoading()
+            }
+            return cell
+        }
         
         if(indexPath.row ==  tableView.numberOfRows(inSection: 0) - 1){
             return tableView.dequeueReusableCell(for: indexPath, cellType: AddTodoInCategoryTableViewCell.self)
@@ -351,3 +398,35 @@ extension CategoryViewController: UICollectionViewDelegate, UICollectionViewData
         cell.setDeselectState()
     }
 }
+
+//MARK: - Pageable
+
+ extension CategoryViewController{
+ 
+     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+         let offsetY = scrollView.contentOffset.y
+         let contentHeight = scrollView.contentSize.height
+         let height = scrollView.frame.height
+         
+         // 스크롤이 테이블 뷰 Offset의 끝에 가게 되면 다음 페이지를 호출
+         if offsetY > (contentHeight - height) {
+             if isPaging == false && hasNextPage {
+                 beginPaging()
+             }
+         }
+     }
+     
+     func beginPaging(){
+         isPaging = true
+         page = page + 1
+
+         DispatchQueue.main.async { [self] in
+             mainView.todoTableView.reloadSections(IndexSet(integer: 1), with: .none)
+         }
+
+         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+             self.requestGetTodoByCategory()
+         }
+     }
+ }
+ 

--- a/Todoary-iOS/Todoary/Presentation/ViewControllers/Summary/Category/CategoryViewController.swift
+++ b/Todoary-iOS/Todoary/Presentation/ViewControllers/Summary/Category/CategoryViewController.swift
@@ -323,7 +323,6 @@ extension CategoryViewController: UICollectionViewDelegate, UICollectionViewData
             
             let data = categories[indexPath.row]
             cell.bindingData(title: data.title, color: data.color)
-
             cell.addGestureRecognizer(UILongPressGestureRecognizer(target: self,
                                                                    action: #selector(categoryBottomSheetWillShowAndModifyCategory)))
             


### PR DESCRIPTION
## What is this PR? 🔍

요약화면 투두 카테고리 Tag UI 오류 수정

## Key Changes 🔑

+ 요약화면 투두에서 카테고리 4-5글자인 경우 레이아웃이 깨지는 UI 버그 발생
+ category designSystem 적용 후, 레이아웃 코드는 수정이 이뤄지지 않았었음
+ designsystem 바탕으로 레이아웃 코드 수정 완료했으며, 기존에 사용하던 category width 관련 프로퍼티 제거

## To Reviewers 📢
- 오류 해결했습니다~


## Related Issues ⛱
close #407