### PR TITLE
로그인 탈퇴로직 구현 및 calendar 비율조정

### DIFF
--- a/Todoary-iOS/Todoary/Presentation/ViewControllers/Todo/TodoCalendarBottomSheetViewController.swift
+++ b/Todoary-iOS/Todoary/Presentation/ViewControllers/Todo/TodoCalendarBottomSheetViewController.swift
@@ -161,6 +161,8 @@ class TodoCalendarBottomSheetViewController: UIViewController {
         
         self.initView()
         
+        self.view.layoutIfNeeded()
+        
         scrollView.delegate = self
         scrollView.showsHorizontalScrollIndicator = false
         
@@ -236,12 +238,13 @@ class TodoCalendarBottomSheetViewController: UIViewController {
         ])
         
         year_Month.snp.makeConstraints{ make in
-            make.top.equalTo(bottomSheetView.snp.top).offset(25)
+            make.top.equalTo(completeBtn.snp.top).offset(36)
+            make.height.equalTo(20)
             make.leading.equalTo(bottomSheetView.snp.leading).offset(51)
         }
         
         weekCollectionView.snp.makeConstraints{ make in
-            make.top.equalTo(year_Month.snp.bottom).offset(0)
+            make.top.equalTo(year_Month.snp.bottom).offset(20)
             make.leading.equalTo(bottomSheetView.snp.leading)
             make.trailing.equalTo(bottomSheetView.snp.trailing)
             make.width.equalTo(screenSize.width)

--- a/Todoary-iOS/Todoary/Presentation/ViewControllers/Todo/TodoSettingViewController.swift
+++ b/Todoary-iOS/Todoary/Presentation/ViewControllers/Todo/TodoSettingViewController.swift
@@ -86,6 +86,8 @@ class TodoSettingViewController : BaseViewController, AlarmComplete, CalendarCom
         flowLayout.scrollDirection = .vertical
         flowLayout.minimumInteritemSpacing = CGFloat(8)
         
+        rightButton.isEnabled = true
+        
         
         //카테고리 컬렉션뷰(수평스크롤)
         mainView.collectionView.collectionViewLayout = flowLayout
@@ -137,6 +139,7 @@ class TodoSettingViewController : BaseViewController, AlarmComplete, CalendarCom
     
     //완료버튼 누르기 -> 투두생성api 호출 및 성공 시 홈화면 이동
     @objc func todocompleteBtnDidTap() {
+        rightButton.isEnabled = false
         
         //TODO: 투두 글자수 20자 이하 제한 걸기
         if todoSettingData.todoId != -1 {


### PR DESCRIPTION
## What is this PR? 🔍
로그인 탈퇴로직 구현 및 calendar 비율조정 및 투두생성수정 버튼 비활성화
## Key Changes 🔑
1. 로그인 탈퇴 로직 구현
   - 탈퇴한 이메일일시 복구 기회를 주는 alert 띄우기 -> 네 선택시 복구 / 아니오 선택시 취소
2. 투두설정부분 캘린더가 비율이 깨지는 핸드폰 발견 -> 비율 맞도록 수정
3. 투두생성수정 버튼 서버요청이 중복되지않도록 한번 누르면 비활성화 되도록 수정

## To Reviewers 📢
- 풀받고 써주세요


## Related Issues ⛱
